### PR TITLE
Fastboot instructions

### DIFF
--- a/_data/devices/m8.yml
+++ b/_data/devices/m8.yml
@@ -14,7 +14,8 @@ cpu_freq: 2.3 GHz
 current_branch: 14.1
 depth: 9.35 mm (0.37 in)
 download_boot: With the device powered down, hold the Volume Down and Power buttons
-  until HBOOT appears, then release the buttons.
+  until HBOOT appears, then release the buttons. Navigate using the volume keys and
+  select FASTBOOT using the Power key.
 gpu: Adreno 330
 gsm: HSDPA 850 / 1900 / 2100 - AT&T<br>HSDPA 850 / 1700 / 1900 / 2100 - T-Mobile
 has_recovery_partition: true


### PR DESCRIPTION
Edited line for entering fastboot to include selecting the fastboot mode. Holding down volume down while booting will only enter HBOOT, and to use fastboot from a PC the device must be set to fastboot from HBOOT.