### PR TITLE
xt897: update specs to reflect real-world usage

### DIFF
--- a/_data/devices/xt897.yml
+++ b/_data/devices/xt897.yml
@@ -12,7 +12,8 @@ cpu_cores: '2'
 cpu_freq: 1.5 GHz
 current_branch: 13.0
 depth: 13.7 mm (0.54 in)
-download_boot: With the device powered down, hold the Volume Up, Down and Power buttons.  Quickly highlight 'AP fastboot' from the menu using the Volume Down button, and push the Volume Up button.
+download_boot: With the device powered down, hold the Volume Down and Power buttons for 3 seconds.
+  First release Power, then release Volume Down.
 gpu: Adreno 225
 has_recovery_partition: true
 height: 126.5 mm (4.98 in)
@@ -22,18 +23,19 @@ kernel: android_kernel_motorola_msm8960-common
 maintainers: [nadlabak, mccreary]
 name: Photon Q 4G LTE
 network:
-- {tech: 2G, bands: '800 1900 MHz CDMA' }
-- {tech: 3G, bands: 'CDMA2000 1xEV-DO' }
-- {tech: 4G, bands: '25(1900)' }
+- {tech: 2G, bands: '800 850 1900 MHz CDMA, 850 900 1800 1900 MHz GSM' }
+- {tech: 3G, bands: 'CDMA2000 1xEV-DO, 1(2100) 2(1900) 5(850) HSPA+' }
+- {tech: 4G, bands: '2/25(1900) LTE' }
 peripherals: [Hardware keyboard, Accelerometer, Compass, GPS, NFC, Light sensor, Proximity sensor]
 ram: 1 GB
 recovery_boot: With the device powered down, hold the Volume Up and Power buttons.
+  Release the Power button once the Motorola logo or unlock warning appears, but continue holding Volume Up until recovery boot starts.
 release: 2012 August 19
 screen: 110 mm (4.3 in)
 screen_ppi: 256
 screen_res: 540x960
 screen_tech: TFT capacitive touchscreen
-sdcard: microSD, up to 32 GB
+sdcard: microSD(XC), up to 256 GB
 soc: Qualcomm MSM8960 Snapdragon S4 Plus
 storage: 8 GB
 tree: android_device_motorola_xt897


### PR DESCRIPTION
- fastest way to fastboot mode is Power + VolDown only; the special
  selection menu is rarely needed on this device

- let go of the power button on the way to recovery, as the device may
  power off/reboot before recovery starts if it stays held the whole time

- the device fully supports both CDMA and GSM on various bands, even
  though does not possess a proper SIM slot (hacks exist for replacing
  soldered RUIM with standard SIM); document what the radio supports

- microSD slot and controller fully support up to 256G SDXC cards --
  probably larger -- stress tested with no issues (UHS-3 speed capable)