### PR TITLE
Correct the usage of extract-files.sh

### DIFF
--- a/pages/extracting_blobs_from_zips.md
+++ b/pages/extracting_blobs_from_zips.md
@@ -41,7 +41,7 @@ $ sudo mount system.img system/
 
 After you have mounted the image, move to the root directory of the sources of your device and run `extract-files.sh` as follows:
 ```
-$ ./extract-files.sh -d ~/android/system_dump/
+$ ./extract-files.sh ~/android/system_dump
 ```
 This will tell `extract-files.sh` to get the files from the mounted system dump rather than from a connected device.
 
@@ -67,7 +67,7 @@ where `path/to/` is the path to the installable zip.
 
 After you have extracted the `system` folder, move to the root directory of the sources of your device and run `extract-files.sh` as follows:
 ```
-$ ./extract-files.sh -d ~/android/system_dump/
+$ ./extract-files.sh ~/android/system_dump
 ```
 This will tell `extract-files.sh` to get the files from the extracted system dump rather than from a connected device.
 


### PR DESCRIPTION
When using extract-files.sh with the -d flag there is an error telling there is an unsupported
amount of parameters. Without -d everything works.
Additionally, the ending slash of the command ([...]/system_dump/) caused "file not found"
errors, so they were removed.

Both changes tested by building lge/h815.

Change-Id: I81966191345a271a6f22834d8c86eabaa2b7775f