### PR TITLE
Remove invalid download_boot and recovery_boot

### DIFF
--- a/_data/devices/h815.yml
+++ b/_data/devices/h815.yml
@@ -12,7 +12,6 @@ cpu_cores: '6'
 cpu_freq: 4 x 1.44 GHz + 2 x 1.82 GHz
 current_branch: 14.1
 depth: 9.8mm (0.39 in)
-download_boot: Volume Up & Power
 gpu: Adreno 418
 has_recovery_partition: true
 height: 148.9 mm (5.86 in)
@@ -27,7 +26,6 @@ network:
 - {tech: 4G, bands: '1(2100) 17(700) 5(850) 4(1700/2100) 3(1800) 7(2600) 2(1900) 8(900) 20(800) 28(700)' }
 peripherals: [Accelerometer, Gyroscope, Proximity sensor, Compass, Barometer, Color spectrum, FM Radio]
 ram: 3 GB
-recovery_boot: Hold Volume Down & Power till LG logo appears, then release Power for 1 sec and hold it again till recovery comes up
 release: June 2015
 screen: 139.7 mm (5.5 in)
 screen_ppi: '538'


### PR DESCRIPTION
There is no key combination that will take you to fastboot or recovery. It is possible to get into "Factory reset" mode using the recovery_boot procedure described currently but that will not take you to recovery. It is possible to go to "Download mode" by holding volume up and then plugging in the USB cable, but that is not fastboot.