### PR TITLE
I9100 install warning and small typos

### DIFF
--- a/_includes/templates/recovery_install_heimdall.md
+++ b/_includes/templates/recovery_install_heimdall.md
@@ -4,14 +4,14 @@ Samsung devices come with a unique boot mode called "Download mode", which is ve
 [Heimdall](http://www.glassechidna.com.au/products/heimdall/) is a cross-platform, open-source tool for interfacing with Download mode on Samsung devices.
 The preferred method of installing a custom recovery is through this boot mode{% unless custom_root_instructions %} -- rooting the stock firmware is neither necessary nor required{% endunless %}.
 
-1. Download and install the [Heimdall suite](http://glassechidna.com.au/heimdall/#downloads)
+1. Download and install the [Heimdall suite](http://glassechidna.com.au/heimdall/#downloads):
     * **Windows**: Extract the Heimdall suite and take note of the directory containing `heimdall.exe`. You can verify Heimdall is working by opening a command
     prompt in that directory and typing `heimdall version`. If you receive an error, make sure you have the 
     [Microsoft Visual C++ 2012 Redistributable Package (x86)](https://www.microsoft.com/en-us/download/details.aspx?id=30679) installed on your computer.
     * **Linux**: Pick the appropriate package to install for your distribution. The `-frontend` packages aren't needed for this guide. After installation,
     verify Heimdall is installed by running `heimdall version` in the terminal.
     * **macOS**: Install the `dmg` package. After installation, Heimdall should be available from the terminal - type `heimdall version` to double-check.
-2. Power off the your device and connect the USB adapter to the computer (but not to the device, yet).
+2. Power off the device and connect the USB adapter to the computer (but not to the device, yet).
 3. Boot into download mode:
 
     * {{ site.data.devices[page.device].download_boot }}

--- a/pages/install/i9100.md
+++ b/pages/install/i9100.md
@@ -7,4 +7,17 @@ redirect_from: i9100_install.html
 permalink: /devices/i9100/install
 device: i9100
 ---
+{% include important.html content="The following documentation does not consider some specific points of the i9100 and thus will not work!"%}
+
+Points that this procedure does currently not consider:
+
+* Booting a custom recovery requires to previously install a kernel which provides [Isolated Recovery](https://forum.xda-developers.com/galaxy-s2/orig-development/isorec-isolated-recovery-galaxy-s2-t3291176) (IsoRec), like the one provided in LineageOS.
+* TWRP, the custom recovery used in this documentation, [does not seem to work](https://github.com/TeamWin/Team-Win-Recovery-Project/issues/1002) with this device in its last version.
+* The default partitions' sizes are not suitable for LineageOS.
+
+If you can not wait for this procedure to be corrected:
+
+1. Read it carefully to understand the general procedure.
+2. Gather and follow instructions from the [following subreddit page](https://www.reddit.com/r/LineageOS/comments/603qeq/cannot_boot_into_twrp_on_samsung_galaxy_s2/).
+
 {% include templates/device_install.md %}


### PR DESCRIPTION
Hi,

The current install instructions provided for the I9100 are unfortunately not correct. Two day ago, I contacted the I9100 maintainer, lysergic_acid, via the XDA forums form (I could not find a better way to contact him). I did not receive an answer yet.

I had a look to correct the documentation myself. However, I am not able to provide a good correction because the page contains many includes and I can not find the proper way to deal with them.

Consequently, this pull request is meant to provide a temporary warning with additional info to avoid loss of time to other people: it is far from a good solution, but I think it is much better than the current state.

Thanks for your work and best regards,
Yvan