### PR TITLE
herolte: Explain how to turn off the device from download mode

### DIFF
--- a/_data/devices/herolte.yml
+++ b/_data/devices/herolte.yml
@@ -13,6 +13,7 @@ cpu_freq: 4 x 2.3 GHz + 4 x 1.6 GHz
 current_branch: 14.1
 depth: 7.9 mm (0.31 in)
 download_boot: With the device powered off, hold <kbd>Volume Down</kbd> + <kbd>Home</kbd> + <kbd>Power</kbd>.
+download_off: From the download mode, you can turn off the device by plugging it to the wall (not a computer) and holding <kbd>Volume Down</kbd> + <kbd>Power</kbd>.
 gpu: ARM Mali-T880 MP12
 has_recovery_partition: true
 height: 142.4 mm (5.61 in)

--- a/_includes/templates/recovery_install_heimdall.md
+++ b/_includes/templates/recovery_install_heimdall.md
@@ -65,4 +65,9 @@ The preferred method of installing a custom recovery is through this boot mode{%
 7. Manually reboot into recovery:
     * {{ site.data.devices[page.device].recovery_boot }}
 
+    {% if site.data.devices[page.device].download_off %}
+    {% capture download_off %}{{ site.data.devices[page.device].download_off }}{% endcapture %}
+    {% include note.html content=download_off %}
+    {% endif %}
+
     {% include note.html content="Be sure to reboot into recovery immediately after having installed the custom recovery. Otherwise the custom recovery will be overwritten and the device will reboot (appearing as though your custom recovery failed to install)." %}


### PR DESCRIPTION
I lost a couple hours because of this:

* the obvious "hold the power button" didn't power off the device
* volume-down+power would reboot the device to Android, overwriting TWRP, forcing me to start again from scratch

It does feel like some obscure voodoo, but this is the only way I found which worked, and I'd rather not have others waste their time like I did. 🙂 