### PR TITLE
Xperia SP has no recovery partition - bad documentation!

### DIFF
--- a/_data/devices/huashan.yml
+++ b/_data/devices/huashan.yml
@@ -14,7 +14,7 @@ current_branch: 14.1
 depth: 10.6 mm
 download_boot: With the device powered off, hold <kbd>Volume Up</kbd> and connect the USB cable. The notification light should turn blue.
 gpu: Adreno 320
-has_recovery_partition: true
+has_recovery_partition: false
 height: 133 mm
 image: huashan.png
 install_method: fastboot_sony


### PR DESCRIPTION
Xperia SP has no recovery partition, so instead of non-working:

fastboot flash recovery twrp-x.x.x-x-huashan.img

it should be (working):

fastboot flash boot twrp-x.x.x-x-huashan.img

I guess changing one line (has_recovery_partition: true -> false) does the trick, if this is not the solution tell me what should I do instead, please.