### PR TITLE
Fix TWRP codename/link

### DIFF
--- a/_data/devices/kltedv.yml
+++ b/_data/devices/kltedv.yml
@@ -11,6 +11,7 @@ cpu: Krait 400
 cpu_cores: '4'
 cpu_freq: 2.5 GHz
 current_branch: 14.1
+custom_twrp_codename: klte
 download_boot: With the device powered off, hold <kbd>Volume Down</kbd> + <kbd>Home</kbd> + <kbd>Power</kbd>.
 gpu: Adreno 330
 has_recovery_partition: true


### PR DESCRIPTION
https://dl.twrp.me/kltedv doesn't exist.

kltedv refers to models G900I and G900P
(https://wiki.lineageos.org/devices/kltedv)

The official TWRP page for Samsung Galaxy S5 links the "klte" build to the "International, Americas, and Oceanic" models (which includes G900I and G900P).
https://twrp.me/samsung/samsunggalaxys5qualcomm.html