### PR TITLE
Mido: 16 GB variant is missing.

### DIFF
--- a/_data/devices/mido.yml
+++ b/_data/devices/mido.yml
@@ -37,7 +37,7 @@ screen_res: 1080x1920
 screen_tech: IPS LCD
 sdcard: up to 256 GB (hybrid SIM slot)
 soc: Qualcomm MSM8953 Snapdragon 625
-storage: 32/64 GB
+storage: 16/32/64 GB
 tree: android_device_xiaomi_mido
 type: phone
 vendor: Xiaomi


### PR DESCRIPTION
There's also 16 GB version.