### PR TITLE
Update official OpenGApps

### DIFF
--- a/pages/gapps.md
+++ b/pages/gapps.md
@@ -18,7 +18,7 @@ These packages are only dependent on your OS version and architecture, which can
 
 |Version                   |Link                                                   |
 |--------------------------|-------------------------------------------------------|
-|Lineage 15.1 (Android 8.1)|[MindTheGapps (AFH)](https://androidfilehost.com/?w=files&flid=170282), [MindTheGapps (Codefire)](http://downloads.codefi.re/jdcteam/javelinanddart/gapps)|
+|Lineage 15.1 (Android 8.1)|[OpenGApps](http://opengapps.org/?api=8.1&variant=nano)
 |Lineage 14.1 (Android 7.1)|[OpenGApps](http://opengapps.org/?api=7.1&variant=nano)|
 |Lineage 13.0 (Android 6.0)|[OpenGApps](http://opengapps.org/?api=6.0&variant=nano)|
 


### PR DESCRIPTION
Remove the alternate link for MindTheGapps.Add official 8.1 OpenGApps.