### PR TITLE
Update i9100.yml

### DIFF
--- a/_data/devices/i9100.yml
+++ b/_data/devices/i9100.yml
@@ -1,5 +1,5 @@
 architecture: arm
-battery: {removable: False, capacity: 1650}
+battery: {removable: True, capacity: 1650}
 bluetooth: {spec: 3.0 + HS}
 cameras:
 - {flash: '', info: '8 MP w/ LED-flash'}


### PR DESCRIPTION
Correct battery type as removeable as Galaxy S2 i9100 has removable battery