### PR TITLE
Update HTC One M9 device info because it's dropped

### DIFF
--- a/_data/devices/himaul.yml
+++ b/_data/devices/himaul.yml
@@ -41,6 +41,6 @@ tree: android_device_htc_himaul
 type: phone
 vendor: HTC
 vendor_short: htc
-versions: [13.0, 14.1]
+versions: []
 width: 69.7 mm (2.74 in)
 wifi: 802.11 a/b/g/n/ac (2.4 & 5 GHz)

--- a/_data/devices/himawl.yml
+++ b/_data/devices/himawl.yml
@@ -41,6 +41,6 @@ tree: android_device_htc_himawl
 type: phone
 vendor: HTC
 vendor_short: htc
-versions: [13.0, 14.1]
+versions: []
 width: 69.7 mm (2.74 in)
 wifi: 802.11 a/b/g/n/ac (2.4 & 5 GHz)


### PR DESCRIPTION
[Changelog 15](https://www.lineageos.org/Changelog-15/) mentions HTC One M9 builds have been dropped. It took me weeks to figure out why it disappeared from the downloads page, because the wiki still says it's supported for 13 and 14.1, and the blog isn't searchable. Hopefully this will make it clearer to others in the same position.

I'm not sure whether this is the right fix or whether they should be removed altogether.

