### PR TITLE
remove maintainers

### DIFF
--- a/_data/devices/gtesqltespr.yml
+++ b/_data/devices/gtesqltespr.yml
@@ -18,7 +18,7 @@ height: 212.1 mm (8.35 in)
 image: gtesqltespr.png
 install_method: heimdall
 kernel: android_kernel_samsung_msm8916
-maintainers: [vince2678, deadman96385]
+maintainers: []
 models: [SM-T377P]
 name: Galaxy Tab E 8.0 LTE (Sprint)
 network:


### PR DESCRIPTION
There are no builds available and appear to be no active maintainers for this device. Removing the maintainers should help users looking through the wiki recognize that this is now an unsupported device.