### PR TITLE
Better explanation for recovery mode on gts210vewifi

### DIFF
--- a/_data/devices/gts210vewifi.yml
+++ b/_data/devices/gts210vewifi.yml
@@ -27,7 +27,7 @@ network:
 - {tech: 4G, bands: '' }
 peripherals: [Accelerometer, Compass, Fingerprint reader, GPS, Gyroscope]
 ram: 3 GB
-recovery_boot: With the device powered off, hold <kbd>Home</kbd> + <kbd>Volume Up</kbd> + <kbd>Power</kbd>.
+recovery_boot: With the device powered off, hold <kbd>Home</kbd> + <kbd>Volume Up</kbd> + <kbd>Power</kbd>. In order to quit download mode, it might be necessary to  reboot the system, holding <kbd>Volume Down</kbd> + <kbd>Power</kbd>. As soon as the screen turns off, hold the combination for recovery mode, otherwise it will reboot normally. 
 release: 2016
 screen: 203 mm (9.7 in)
 screen_ppi: 264


### PR DESCRIPTION
This explains the necessary steps for entering recovery mode from download mode fully, making installation easier and less frustrating.

When attempting to install LineageOS on my device, I couldn't turn it off without rebooting, and I didn't know to press the combination for recovery mode before the screen turned back on. Therefore, it took me several flashes of TWRP before I understood what to do. This change can make it easier for people who want to install LineageOS on their tablets.
I can add it to other Samsung Tab S2 files, if someone confirms it works the same.