### PR TITLE
i9300: changed removability mark to true

### DIFF
--- a/_data/devices/i9300.yml
+++ b/_data/devices/i9300.yml
@@ -1,5 +1,5 @@
 architecture: arm
-battery: {removable: False, capacity: 2100, tech: 'Li-Ion'}
+battery: {removable: True, capacity: 2100, tech: 'Li-Ion'}
 bluetooth: {spec: '4.0'}
 cameras:
 - {flash: 'LED', info: '8 MP'}


### PR DESCRIPTION
The battery of the i9300 is removable.