### PR TITLE
Update fastboot_adb_setup.md

### DIFF
--- a/pages/fastboot_adb_setup.md
+++ b/pages/fastboot_adb_setup.md
@@ -44,7 +44,8 @@ if [ -d "$HOME/adb-fastboot/platform-tools" ] ; then
     export PATH="$HOME/adb-fastboot/platform-tools:$PATH"
 fi
 ```
-4. Log out and back in.
+4. Run `source ~/.bash_profile`
+5. Test the install is successful by running `adb`.
 
 ### On Linux
 1. Download the [Linux zip](https://dl.google.com/android/repository/platform-tools-latest-linux.zip) from Google.


### PR DESCRIPTION
Edited the `fastboot_adb_setup.md` page to add how to reload your bash profile without logging in and out again/closing and reopening the terminal, and how to show you've installed it correctly.