### PR TITLE
Xubuntu 18.04 with S5 900F require heimdall 1.4.2

### DIFF
--- a/_data/devices/klte.yml
+++ b/_data/devices/klte.yml
@@ -44,3 +44,4 @@ vendor_short: samsung
 versions: [14.1, 15.1, 16.0]
 width: 72.5 mm (2.85 in)
 wifi: 802.11 a/b/g/n/ac
+custom_upgrade_heimdall_notice: True

--- a/_includes/templates/recovery_install_heimdall.md
+++ b/_includes/templates/recovery_install_heimdall.md
@@ -38,6 +38,9 @@ The preferred method of installing a custom recovery is through this boot mode{%
 heimdall print-pit
 ```
 7. If the device reboots, Heimdall is installed and working properly.
+{% if custom_upgrade_heimdall_notice %}
+In case of failure, try to install heimdall 1.4.2+. This is available from [source](https://gitlab.com/BenjaminDobell/Heimdall).
+{% endif %}
 
 {% if custom_downgrade_instructions %}
 {{ custom_downgrade_instructions }}


### PR DESCRIPTION
I tried to flash Samsung S5 900F with Xubuntu 18.04 using heimdall 1.4.1 and there was some problem with checking the end of files.

Using heimdall 1.4.2 worked. Unfortunately, this is not available as a prebuild on https://www.glassechidna.com.au/heimdall/#downloads

This might also be relevant to more devices. (I bricked some S3 mini ignoring this problem.)