### PR TITLE
Nexus 5X: Li-Ion not Li-Polymer battery

### DIFF
--- a/_data/devices/bullhead.yml
+++ b/_data/devices/bullhead.yml
@@ -1,5 +1,5 @@
 architecture: arm64
-battery: {removable: False, capacity: 2700, tech: 'Li-Po'}
+battery: {removable: False, capacity: 2700, tech: 'Li-Ion'}
 bluetooth: {spec: '4.2', profiles: [A2DP]}
 cameras:
 - {flash: 'Dual LED (dual tone)', info: '12.3 MP, laser autofocus'}


### PR DESCRIPTION
see https://www.lg.com/de/handy/lg-Nexus-5X