### PR TITLE
use sideloading for gapps install

### DIFF
--- a/pages/gapps.md
+++ b/pages/gapps.md
@@ -30,7 +30,7 @@ Google apps should be installed via recovery **immediately** after installing Li
 
 {% include alerts/important.html content="If you reboot into LineageOS before installing Google apps, you must factory reset and then install them, otherwise expect crashes." %}
 
-1. Copy the Google apps zipfile to `/sdcard/`
-    * Using [adb](adb_fastboot_guide.html): `adb push filename.zip /sdcard/`
-2. After installing LineageOS, choose "install zip" or "Apply update" in recovery, and navigate to the zipfile loaded earlier.
-3. Reboot to system (i.e. LineageOS).
+1. Still in recovery after installing LineageOS sideload the Google apps package the same way:
+    * On the device, select “Advanced”, “ADB Sideload”, then swipe to begin sideload.
+    * On the host machine, sideload the Google apps package using: `adb sideload filename.zip`
+2. In recovery select “Reboot” to trigger LineageOS first boot.


### PR DESCRIPTION
The manual install doesn't work for all users (e.g. me). While in recovery after sideloading LineageOS `adb push` fails as does `adb devices`. It's also inconsistent with the LineageOS install guide (e.g. https://wiki.lineageos.org/devices/santoni/install). Sideloading the Google apps package instead of the old two step way is consistent and simpler, too.