### PR TITLE
Add missing info for h850

### DIFF
--- a/_includes/templates/recovery_install_fastboot_lg.md
+++ b/_includes/templates/recovery_install_fastboot_lg.md
@@ -38,3 +38,5 @@ fastboot getvar unlocked
 {% include alerts/tip.html content="It is highly recommended to have the latest official LG stock package installed on the device, before proceeding with unlock." %}
 
 {% include templates/recovery_install_fastboot_generic.md %}
+
+{% include alerts/note.html content="For h850: for TWRP to _stick_ you must first boot directly into TWRP and not back into Android. After flashing TWRP unplug the USB cable and pull the battery. Plug battery back in then boot into recovery which should load TWRP." %}


### PR DESCRIPTION
Getting the recovery to work on LG G5 h850 requires additional steps.
These are outlined on https://forum.xda-developers.com/lg-g5/development/official-european-lg-g5-h850-bootloader-t3363040
I wrote the note in the lg file, cause I don't know how to make it appear
just for a specific device; someone more expert at this could make this better.

Change-Id: I5922a7c62870a59681f5ebfc90ffbfcefee564fa