### PR TITLE
Add missing python dependency

### DIFF
--- a/_includes/templates/device_build.md
+++ b/_includes/templates/device_build.md
@@ -81,7 +81,7 @@ To build LineageOS, you'll need:
 
 * `bc bison build-essential ccache curl flex g++-multilib gcc-multilib git gnupg gperf imagemagick
    lib32ncurses5-dev lib32readline-dev lib32z1-dev liblz4-tool libncurses5 libncurses5-dev
-   libsdl1.2-dev libssl-dev libxml2 libxml2-utils lzop pngcrush rsync
+   libsdl1.2-dev libssl-dev libxml2 libxml2-utils lzop pngcrush python rsync
    schedtool squashfs-tools xsltproc {% if cpu_architecture contains 'x86' %}yasm {% endif %}
    zip zlib1g-dev`
 


### PR DESCRIPTION
Python is required by "repo" command and not installed by default using an Ubuntu Server 20.04 installation.