### PR TITLE
Update twolip.yml (correction of SoC reference)

### DIFF
--- a/_data/devices/twolip.yml
+++ b/_data/devices/twolip.yml
@@ -32,7 +32,7 @@ screen_ppi: '403'
 screen_res: 1080x2280
 screen_tech: IPS LCD
 sdcard: up to 256 GB
-soc: Qualcomm SDM660 Snapdragon 636
+soc: Qualcomm SDM636 Snapdragon 636
 storage: 32/64 GB
 tree: android_device_xiaomi_twolip
 type: phone


### PR DESCRIPTION
Correction of the SoC reference (SnapDragon 636 = SDM636)

Source : https://www.gsmarena.com/xiaomi_redmi_note_6_pro-9333.php
and https://en.wikipedia.org/wiki/List_of_Qualcomm_Snapdragon_systems-on-chip#Snapdragon_630,_636_and_660_(2017)