### PR TITLE
Update i9300.yml

### DIFF
--- a/_data/devices/i9300.yml
+++ b/_data/devices/i9300.yml
@@ -9,6 +9,7 @@ cpu: Cortex-A9
 cpu_cores: 4
 cpu_freq: 1.4GHz
 current_branch: 14.1
+custom_twrp_link: https://dl.twrp.me/i9300/twrp-3.2.3-0-i9300.img
 depth: 8.6 mm (0.34 in)
 download_boot: With the device powered off, hold <kbd>Home</kbd> + <kbd>Volume Down</kbd> + <kbd>Power</kbd>.
 gpu: ARM Mali-400 MP4


### PR DESCRIPTION
custom_twrp_link to TWRP v3.2.3-0-i9300 due to Samsung Galaxy S3 ADB incompatibility in v3.3/3.4 - https://github.com/TeamWin/Team-Win-Recovery-Project/issues/1500

Removes installation instruction to "Simply download the latest recovery file"