### PR TITLE
Add device release date to device list

### DIFF
--- a/pages/devices.html
+++ b/pages/devices.html
@@ -68,7 +68,8 @@ Select a vendor to jump to:<br/>
   <tr>
     <th scope="col" class="first"><b>Device</b></th>
     <th scope="col"><b>Codename</b></th>
-    <th scope="col" class="last"><b>Type</b></th>
+    <th scope="col"><b>Type</b></th>
+    <th scope="col" class="last"><b>Release date</b></th>
   </tr>
   </thead>
 {% endif %}
@@ -83,6 +84,18 @@ Select a vendor to jump to:<br/>
     <th scope="row" onClick="location.href='{{ url }}'"><a href="{{ url }}">{{ deviceName }}</a></th>
     <td onClick="location.href='{{ url }}'"><a href="{{ url }}">{{ device.codename }}</a></td>
     <td>{{ device.type | capitalize }}</td>
+    {% if device.release.first %}
+    <td>
+      {%- for entries in device.release %}
+        {%- for item in entries %}
+          {{ item[0] }}: {{ item[1] }}
+        {%- endfor %}
+        {%- unless forloop.last %}, {% endunless %}
+      {%- endfor %}
+    </td>
+    {% else %}
+    <td>{{ device.release }}</td>
+    {% endif %}
   </tr>
 {% if sorted[forloop.index].vendor != lastVendor %}</table>{% endif %}
 {% endfor %}


### PR DESCRIPTION
This PR adds a "Release date" column to the device page. It's a thing I've missed whenever I'm looking for a new device that supports LineageOS, and frees the user from clicking through to device details only to immediately go back because the device is from 2014 and you need something newer.

Sample:
![devices](https://user-images.githubusercontent.com/626791/91645999-0a088a00-ea4b-11ea-9d7a-0bdb450c139a.png)
