### PR TITLE
wiki: dumpling: Update sideload instructions

### DIFF
--- a/_includes/templates/device_specific/before_lineage_install_dumpling.md
+++ b/_includes/templates/device_specific/before_lineage_install_dumpling.md
@@ -2,5 +2,5 @@
 
 1. Download the latest firmware zip file for dumpling from [here](https://sourceforge.net/projects/lineageos-cheeseburger/files/firmware/dumpling/).
 3. Sideload the firmware `.zip` package:
-    * On the device, select "Advanced", "ADB Sideload", then swipe to begin sideload.
+    * On the device, select "Apply update", then "Apply from ADB" to begin sideload.
     * On the host machine, sideload the package using: `adb sideload filename.zip`


### PR DESCRIPTION
Update the firmware sideload instructions for dumpling to match the LineageOS Recovery version 17.1 (2020110). There is no option "ADB Sideload" under the main menu item "Advanced". Instead, the option "Apply from ADB" is available under "Apply updated".