### PR TITLE
Add note about instabilities related to Fairphone 3+ and LineageOS 16.0

### DIFF
--- a/pages/install/FP3.md
+++ b/pages/install/FP3.md
@@ -5,4 +5,5 @@ folder: install
 permalink: /devices/FP3/install
 device: FP3
 ---
+{% include alerts/warning.html content="Do not attempt to install Lineage 16.0 or below on a Fairphone 3+ (or a Fairphone 3 with any of the new 3+ modules), or you will experience instabilities in apps that use the new modules, such as camera or phone apps, as they require Android 10 to function properly." %}
 {% include templates/device_install.md %}


### PR DESCRIPTION
Hey. This PR is just a small addition to [the instructions on installing LineageOS on Fairphone 3](https://wiki.lineageos.org/devices/FP3/install) . The current instructions don't distinguish between Fairphone 3 and Fairphone 3+ (which is basically the same modular phone, but with some upgraded modules), but installing LineageOS 16.0 on Fairphone 3+ causes a bunch of crashes for the camera and call apps due to the new modules requiring Android 10. (more [here](https://www.reddit.com/r/fairphone/comments/js40yb/lineageos_on_fairphone_3/) )

Since the instructions didn't mention this, I have added a small warning for anyone wanting to install LineageOS on FP3+ . I'm not familiar with Jekyll so if I effed up the syntax I apologize.

Change-Id: I72bfb0bc82c1dd085689f1db46ee94ded3b4a452