### PR TITLE
Update jag3gds.yml

### DIFF
--- a/_data/devices/jag3gds.yml
+++ b/_data/devices/jag3gds.yml
@@ -18,7 +18,7 @@ image: jag3gds.png
 install_method: dd
 kernel: android_kernel_lge_msm8226
 maintainers: []
-name: G3 S
+name: G3 Beat
 network: [2G GSM, 3G UMTS]
 peripherals: [GPS, Accelerometer, Compass, Proximity sensor, FM radio]
 ram: 1 GB


### PR DESCRIPTION
Confusion between G3s (jagnm, LG-D722, 4G-compatible) and G3 Beat (jag3gds, LG-D724, 3G-only)