### PR TITLE
Add release year filter on devices page

### DIFF
--- a/_data/devices/cancro.yml
+++ b/_data/devices/cancro.yml
@@ -35,8 +35,10 @@ ram: 2 GB (Mi 3) / 3 GB (Mi 4)
 recovery_boot: With the device powered off, hold <kbd>Volume Up</kbd> + <kbd>Power</kbd>.
   Keep holding both buttons until the "MI" logo appears on the screen, then release.
 release:
-- MI3: 2013-10
-- MI4: 2014-08
+- model: MI3
+  date: 2013-10
+- model: MI4
+  date: 2014-08
 screen: 127 mm (5 in)
 screen_ppi: 441
 screen_res: 1080x1920

--- a/_data/devices/find7.yml
+++ b/_data/devices/find7.yml
@@ -27,8 +27,10 @@ peripherals: [Light sensor, Proximity sensor, Gyroscope, Accelerometer, GPS, GLO
 ram: 2/3 GB
 recovery_boot: With the device powered off, hold <kbd>Volume Down</kbd> + <kbd>Power</kbd>.
 release:
-- Find 7a: 2014-03-19
-- Find 7s: 2014-05-19
+- model: Find 7a
+  date: 2014-03-19
+- model: Find 7s
+  date: 2014-05-19
 screen: 139.7 mm (5.5 in)
 screen_ppi: '401/534'
 screen_res: 1920x1080/1440x2560

--- a/_data/devices/ginkgo.yml
+++ b/_data/devices/ginkgo.yml
@@ -28,8 +28,10 @@ ram: 3/4/6 GB
 recovery_boot: With the device powered off, hold <kbd>Volume Up</kbd> + <kbd>Power</kbd>.
   Keep holding both buttons until the "MI" logo appears on the screen, then release.
 release:
-- Note 8: 2019-08
-- Note 8T: 2019-11
+- model: Note 8
+  date: 2019-08
+- model: Note 8T
+  date: 2019-11
 screen: 160 mm (6.3 in)
 screen_ppi: '409'
 screen_res: 1080x2340

--- a/_data/devices/kltechn.yml
+++ b/_data/devices/kltechn.yml
@@ -25,8 +25,10 @@ peripherals: [Fingerprint reader, Heart rate sensor, Motion Coprocessor, Acceler
 ram: 2 GB
 recovery_boot: With the device powered off, hold <kbd>Volume Up</kbd> + <kbd>Home</kbd> + <kbd>Power</kbd>. When the blue text appears, release the buttons.
 release:
-- SM-G9006V: 2014-04
-- SM-G9008V: 2014-05
+- model: SM-G9006V
+  date: 2014-04
+- model: SM-G9008V
+  date: 2014-05
 screen: 130 mm (5.1 in)
 screen_ppi: '432'
 screen_res: 1920x1080

--- a/_data/devices/kltechnduo.yml
+++ b/_data/devices/kltechnduo.yml
@@ -25,9 +25,12 @@ peripherals: [Fingerprint reader, Heart rate sensor, Motion Coprocessor, Acceler
 ram: 2 GB
 recovery_boot: With the device powered off, hold <kbd>Volume Up</kbd> + <kbd>Home</kbd> + <kbd>Power</kbd>. When the blue text appears, release the buttons.
 release:
-- SM-G9006W: 2014-04
-- SM-G9008W: 2014-06
-- SM-G9009W: 2014-04
+- model: SM-G9006W
+  date: 2014-04
+- model: SM-G9008W
+  date: 2014-06
+- model: SM-G9009W
+  date: 2014-04
 screen: 130 mm (5.1 in)
 screen_ppi: '432'
 screen_res: 1920x1080

--- a/_data/devices/klteduos.yml
+++ b/_data/devices/klteduos.yml
@@ -25,8 +25,10 @@ peripherals: [Fingerprint reader, Heart rate sensor, Motion Coprocessor, Acceler
 ram: 2 GB
 recovery_boot: With the device powered off, hold <kbd>Volume Up</kbd> + <kbd>Home</kbd> + <kbd>Power</kbd>. When the blue text appears, release the buttons.
 release:
-- SM-G900FD: 2014-06
-- SM-G900MD: 2014-07
+- model: SM-G900FD
+  date: 2014-06
+- model: SM-G900MD
+  date: 2014-07
 screen: 130 mm (5.1 in)
 screen_ppi: '432'
 screen_res: 1920x1080

--- a/_data/devices/oneplus3.yml
+++ b/_data/devices/oneplus3.yml
@@ -28,8 +28,10 @@ peripherals: [Dual SIM, Fingerprint reader, Accelerometer, Gyroscope, Proximity 
 ram: 6 GB LPDDR4
 recovery_boot: With the device powered off, hold <kbd>Volume Down</kbd> + <kbd>Power</kbd>.
 release:
-- A3000: 2016-06
-- A3003: 2016-10
+- model: A3000
+  date: 2016-06
+- model: A3003
+  date: 2016-10
 screen: 139.7 mm (5.5 in)
 screen_ppi: '401'
 screen_res: 1080x1920

--- a/_data/devices/r5.yml
+++ b/_data/devices/r5.yml
@@ -29,8 +29,10 @@ project_spectrum_recovery: "https://androidfilehost.com/?fid=889964283620757488"
 ram: 2 GB (R5), 3 GB (R5s)
 recovery_boot: With the device powered off, hold <kbd>Volume Down</kbd> + <kbd>Power</kbd>.
 release:
-- R8106: 2014-12
-- R8106s: 2015-08
+- model: R8106
+  date: 2014-12
+- model: R8106s
+  date: 2015-08
 required_bootloader_link: "https://www.androidfilehost.com/?fid=24566382913912839"
 screen: 132 mm (5.2 in)
 screen_ppi: '~423'

--- a/_data/devices/tomato.yml
+++ b/_data/devices/tomato.yml
@@ -28,8 +28,10 @@ peripherals: [GPS, Light sensor, Proximity sensor]
 ram: 2 GB
 recovery_boot: With the device powered off, hold <kbd>Volume Down</kbd> + <kbd>Power</kbd>.
 release:
-- AO5510: 2014-12-18
-- YU5510: 2015-07-24
+- model: AO5510
+  date: 2014-12-18
+- model: YU5510
+  date: 2015-07-24
 screen: 139.7 mm (5.5 in)
 screen_ppi: 267  / 401  (Plus)
 screen_res: 1280x720 / 1920x1080 (Plus)

--- a/_data/devices/vegetalte.yml
+++ b/_data/devices/vegetalte.yml
@@ -28,8 +28,10 @@ ram: 1/2 GB
 recovery_boot: With the device powered off, hold <kbd>Volume Up</kbd> + <kbd>Power</kbd>.
   When the device vibrates, release <kbd>Power</kbd>, wait a second, then release <kbd>Volume Up</kbd>.
 release:
-- E5 4G: 2014
-- E5s: 2015
+- model: E5 4G
+  date: 2014
+- model: E5s
+  date: 2015
 screen: 127 mm (5.0 in)
 screen_ppi: ~294
 screen_res: 720x1280

--- a/_data/devices/zl1.yml
+++ b/_data/devices/zl1.yml
@@ -25,8 +25,10 @@ peripherals: [Dual SIM, Fingerprint reader, Accelerometer, Gyroscope, Proximity 
 ram: 4/6 GB
 recovery_boot: With the device powered off, hold <kbd>Volume Up</kbd> + <kbd>Power</kbd>.
 release:
-- Le Pro3: 2016-10
-- Le Pro3 Elite: 2017-03
+- model: Le Pro3
+  date: 2016-10
+- model: Le Pro3 Elite
+  date: 2017-03
 screen: 139.7 mm (5.5 in)
 screen_ppi: ~403
 screen_res: 1920x1080

--- a/pages/devices.html
+++ b/pages/devices.html
@@ -7,18 +7,37 @@ search: exclude
 ---
 
 <script type="text/javascript">
-function toggleDiscontinued()
+        var classesToHide= [];
+function hideElementsByClass(className)
 {
-  $('.discontinued').toggle();
+  if (classesToHide.includes(className)) {
+    classesToHide = classesToHide.filter(function(value, index, arr) {
+      return value != className;
+    });
+  } else {
+    classesToHide.push(className);
+  }
+
   $("table.device").each(function () {
+    $(this).find("tbody > tr").show();
+
     vendor = $(this).attr("vendor");
-    if ($(this).find("tbody > tr:visible").length == 0 && $(this).is(":visible")) {
+    $("*[vendor=" + vendor + "]").show();
+
+    classesToHide.forEach(element => $("." + element).hide());
+
+    if ($(this).find("tbody > tr:visible").length == 0) {
       $("*[vendor=" + vendor + "]").hide();
-    } else {
-      $("*[vendor=" + vendor + "]").show();
     }
   });
+  classesToHide.forEach(element => $("." + element).hide());
+
+  $(".vendor-container-all").show();
+  if ($(".vendor-container-all").find(".vendor-item:visible").length == 0) {
+    $(".vendor-container-all").hide();
+  }
 }
+
 </script>
 
 <div class="container page">
@@ -26,7 +45,7 @@ function toggleDiscontinued()
   <h1>{{ page.title }}</h1>
 
   Rows with a lower opacity are no longer officially supported and the pages exist for reference only.<br/>
-  You can hide them by unchecking the following checkbox:<br/><br/>
+  You can hide them by unchecking the following checkbox:<br/>
 
 {% assign devices = "" | split: " " %}
 {% for device in site.data.devices %}
@@ -36,14 +55,44 @@ function toggleDiscontinued()
 {% assign sorted = devices | sort_natural: 'name' | sort_natural: 'vendor' %}
 {% assign lastVendor = "" %}
 
-<div class="form-check form-check-inline">
+<div class="form-check form-check-inline row" >
+  <div class="col-sm-12" style="margin: 5px;">
   <label class="form-check-label">
-    <input class="form-check-input" type="checkbox" onclick="toggleDiscontinued()" checked="checked">Show discontinued devices<span class="form-check-sign">
+         <input class="form-check-input container-sm" type="checkbox" onclick="hideElementsByClass('discontinued')" checked="checked">Show discontinued devices<span class="form-check-sign">
         <span class="check"></span>
     </span>
   </label>
+  </div>
+</div><br/>
+  You can also filter the devices by release year:<br/>
+<div class="form-check form-check-inline row">
+  {% for device in devices %}
+    {% if device.release.first %}
+      {% assign releaseYear = device.release.first.date | split: '-' | first %}
+    {% else %}
+      {% assign releaseYear = device.release | split: '-' | first %}
+    {% endif %}
+
+    {% if releaseYears == "" %}
+      {% assign releaseYears = releaseYear %}
+    {% else %}
+      {% assign releaseYears = releaseYear | append: "," | append: releaseYears %}
+    {% endif %}
+  {% endfor %}
+
+  {% assign releaseYears = releaseYears | split: "," | sort | uniq | compact %}
+  {% for year in releaseYears %}
+  <div class="col-sm-2" style="margin: 5px;">
+  <label class="form-check-label">
+          <input class="form-check-input" type="checkbox" onclick="hideElementsByClass('release{{ year }}')" checked="checked">{{ year }}<span class="form-check-sign">
+        <span class="check"></span>
+    </span>
+  </label>
+  </div>
+  {% endfor %}
 </div><br/><br/>
 
+<div class="vendor-container-all">
 Select a vendor to jump to:<br/>
 
 <div class="vendor-container">
@@ -52,16 +101,17 @@ Select a vendor to jump to:<br/>
 {%- if device.vendor != lastVendor %}
 {%- assign vendors = vendors | push: device.vendor %}
 {%- assign lastVendor = device.vendor %}
-  <div vendor="{{ lastVendor | slugify }}"><a href="#{{ lastVendor | slugify }}" vendor="{{ lastVendor | slugify }}">{{ lastVendor }}</a></div>
+  <div vendor="{{ lastVendor | slugify }}" class="vendor-item"><a href="#{{ lastVendor | slugify }}" vendor="{{ lastVendor | slugify }}">{{ lastVendor }}</a></div>
 {%- endif %}
 {%- endfor %}
+</div>
 </div>
 
 {% for device in sorted %}
 {% if device.vendor != lastVendor %}
 {% assign lastVendor = device.vendor %}
 
-<h2 class="h3" id="{{ device.vendor | slugify }}" vendor="{{ device.vendor | slugify }}">{{ device.vendor}}</h2>
+<h2 class="h3" id="{{ device.vendor | slugify }}" vendor="{{ device.vendor | slugify }}">{{ device.vendor }}</h2>
 
 <table class="table device" vendor="{{ device.vendor | slugify }}">
   <thead>
@@ -79,6 +129,18 @@ Select a vendor to jump to:<br/>
 {%- else %}
 {%- assign class="" %}
 {%- endif %}
+
+
+{% if device.release.first %}
+{% endif %}
+
+{% if device.release.first %}
+  {% assign releaseYear = device.release.first.date | split: '-' | first %}
+{% else %}
+  {% assign releaseYear = device.release | split: '-' | first %}
+{% endif %}
+{% assign class = class | append: " release" | append: releaseYear %}
+
   <tr class="{{ class }}">
     <th scope="row" onClick="location.href='{{ url }}'"><a href="{{ url }}">{{ deviceName }}</a></th>
     <td onClick="location.href='{{ url }}'"><a href="{{ url }}">{{ device.codename }}</a></td>


### PR DESCRIPTION
The devices page does now have a filter for
every release year. This makes it easier to
find recent devices and filter old ones.

Change-Id: I02ad349a5e20c40e903a00c06de89e49864a7650

![image](https://user-images.githubusercontent.com/11939569/107938396-9ec55c80-6f85-11eb-8323-1a4171c8feac.png)
