### PR TITLE
Nokia 6.1 (2018) PL2 supports dual SIM

### DIFF
--- a/_data/devices/PL2.yml
+++ b/_data/devices/PL2.yml
@@ -21,7 +21,7 @@ maintainers: [npjohnson, theimpulson]
 models: [TA-1043, TA-1089]
 name: '6.1 (2018)'
 network: [2G GSM, 3G UMTS, 4G LTE]
-peripherals: [Fingerprint reader, Accelerometer, Gyroscope, Proximity sensor, Compass, NFC, GPS]
+peripherals: [Fingerprint reader, Accelerometer, Gyroscope, Proximity sensor, Compass, NFC, GPS, Dual SIM]
 ram: 3/4 GB LPDDR4X
 recovery_boot: With the device powered off and plugged into USB port, hold <kbd>Volume Up</kbd> + <kbd>Power</kbd>.
  Keep holding both buttons until the "Android One" logo appears on the screen, then release <kbd>Power</kbd> but keep


### PR DESCRIPTION
The second SIM slot can be used as either SIM or SD Card. I am not sure if the wiki has a way to distinguish this.

https://www.gsmarena.com/nokia_6_1-8972.php