### PR TITLE
zippo.yml remove unnecessary \t

### DIFF
--- a/_data/devices/zippo.yml
+++ b/_data/devices/zippo.yml
@@ -15,7 +15,7 @@ cpu_cores: '8'
 cpu_freq: 1 x 2.84 GHz + 3 x 2.42 GHz + 4 x 1.78 GHz
 current_branch: 18.1
 custom_unlock_cmd: fastboot oem unlock-go
-depth: 	8.7 mm (0.34 in)
+depth: 8.7 mm (0.34 in)
 download_boot: With the device powered off, hold <kbd>Volume Down</kbd> + <kbd>Power</kbd>.
   Keep holding both buttons until the word "FASTBOOT" appears on the screen, then release.
 gpu: Adreno 640


### PR DESCRIPTION
just to make this yaml parser-friendly